### PR TITLE
Safely check for device name equality

### DIFF
--- a/android/src/main/java/io/generalgalactic/capacitor/esp_idf_provisioning/EspProvisioningBLE.java
+++ b/android/src/main/java/io/generalgalactic/capacitor/esp_idf_provisioning/EspProvisioningBLE.java
@@ -355,7 +355,7 @@ public class EspProvisioningBLE {
         ESPDevice espDevice = this.getESPProvisionManager().getEspDevice();
         if(espDevice == null) return null;
 
-        if( !espDevice.getDeviceName().equals(bleDevice.getName()) ){
+        if( !Objects.equals(espDevice.getDeviceName(), bleDevice.getName()) ){
             debugLog(String.format("Device mismatch. %s != %s", espDevice.getDeviceName(), bleDevice.getName()));
             return null;
         }


### PR DESCRIPTION
Fixes general-galactic/capacitor-esp-idf-provisioning#10